### PR TITLE
Added Anti-Aliasing to the Render Settings

### DIFF
--- a/src/main/java/com/replaymod/render/VideoWriter.java
+++ b/src/main/java/com/replaymod/render/VideoWriter.java
@@ -43,7 +43,8 @@ public class VideoWriter implements FrameConsumer<RGBFrame> {
                     .replace("%HEIGHT%", String.valueOf(settings.getVideoHeight()))
                     .replace("%FPS%", String.valueOf(settings.getFramesPerSecond()))
                     .replace("%FILENAME%", fileName)
-                    .replace("%BITRATE%", String.valueOf(settings.getBitRate()));
+                    .replace("%BITRATE%", String.valueOf(settings.getBitRate()))
+                    .replace("%FILTERS%", settings.getVideoFilters());
 
         String executable = settings.getExportCommand().isEmpty() ? "ffmpeg" : settings.getExportCommand();
         System.out.println("Starting " + settings.getExportCommand() + " with args: " + commandArgs);

--- a/src/main/java/com/replaymod/render/gui/GuiRenderSettings.java
+++ b/src/main/java/com/replaymod/render/gui/GuiRenderSettings.java
@@ -149,13 +149,18 @@ public class GuiRenderSettings extends GuiScreen implements Closeable {
     public final GuiCheckbox inject360Metadata = new GuiCheckbox()
             .setI18nLabel("replaymod.gui.rendersettings.360metadata");
 
+    public final GuiDropdownMenu<RenderSettings.AntiAliasing> antiAliasingDropdown = new GuiDropdownMenu<RenderSettings.AntiAliasing>()
+            .setSize(200, 20).setValues(RenderSettings.AntiAliasing.values()).setSelected(RenderSettings.AntiAliasing.NONE);
+
     public final GuiPanel advancedPanel = new GuiPanel().setLayout(new VerticalLayout().setSpacing(15))
             .addElements(null, nametagCheckbox, new GuiPanel().setLayout(
                     new GridLayout().setCellsEqualSize(false).setColumns(2).setSpacingX(5).setSpacingY(15))
                     .addElements(new GridLayout.Data(0, 0.5),
                             new GuiLabel().setI18nText("replaymod.gui.rendersettings.stabilizecamera"), stabilizePanel,
                             chromaKeyingCheckbox, chromaKeyingColor,
-                            inject360Metadata));
+                            inject360Metadata,
+                            new GuiLabel(), // to show the anti-aliasing options in a new line
+                            new GuiLabel().setI18nText("replaymod.gui.rendersettings.antialiasing"), antiAliasingDropdown));
 
     public final GuiTextField exportCommand = new GuiTextField().setI18nHint("replaymod.gui.rendersettings.command")
             .setSize(55, 20).setMaxLength(100);
@@ -347,8 +352,8 @@ public class GuiRenderSettings extends GuiScreen implements Closeable {
     public void load(RenderSettings settings) {
         renderMethodDropdown.setSelected(settings.getRenderMethod());
         encodingPresetDropdown.setSelected(settings.getEncodingPreset());
-        videoWidth.setValue(settings.getVideoWidth());
-        videoHeight.setValue(settings.getVideoHeight());
+        videoWidth.setValue(settings.getTargetVideoWidth());
+        videoHeight.setValue(settings.getTargetVideoHeight());
         frameRateSlider.setValue(settings.getFramesPerSecond() - 10);
         if (settings.getBitRate() % (1 << 20) == 0) {
             bitRateField.setValue(settings.getBitRate() >> 20);
@@ -380,6 +385,7 @@ public class GuiRenderSettings extends GuiScreen implements Closeable {
             chromaKeyingColor.setColor(settings.getChromaKeyingColor());
         }
         inject360Metadata.setChecked(settings.isInject360Metadata());
+        antiAliasingDropdown.setSelected(settings.getAntiAliasing());
         exportCommand.setText(settings.getExportCommand());
         exportArguments.setText(settings.getExportArguments());
 
@@ -401,6 +407,7 @@ public class GuiRenderSettings extends GuiScreen implements Closeable {
                 stabilizeRoll.isChecked() && (serialize || stabilizeRoll.isEnabled()),
                 chromaKeyingCheckbox.isChecked() ? chromaKeyingColor.getColor() : null,
                 inject360Metadata.isChecked() && (serialize || inject360Metadata.isEnabled()),
+                antiAliasingDropdown.getSelectedValue(),
                 exportCommand.getText(),
                 exportArguments.getText(),
                 net.minecraft.client.gui.GuiScreen.isCtrlKeyDown()
@@ -415,7 +422,7 @@ public class GuiRenderSettings extends GuiScreen implements Closeable {
 
     private RenderSettings getDefaultRenderSettings() {
         return new RenderSettings(RenderSettings.RenderMethod.DEFAULT, RenderSettings.EncodingPreset.MP4_DEFAULT, 1920, 1080, 60, 10 << 20, null,
-                true, false, false, false, null, false, "", RenderSettings.EncodingPreset.MP4_DEFAULT.getValue(), false);
+                true, false, false, false, null, false, RenderSettings.AntiAliasing.NONE, "", RenderSettings.EncodingPreset.MP4_DEFAULT.getValue(), false);
     }
 
     @Override

--- a/src/main/resources/assets/replaymod/lang/en_US.lang
+++ b/src/main/resources/assets/replaymod/lang/en_US.lang
@@ -424,6 +424,12 @@ replaymod.gui.rendersettings.presets.webm.custom=WEBM - Custom Bitrate
 replaymod.gui.rendersettings.presets.mkv.lossless=MKV - Lossless
 replaymod.gui.rendersettings.presets.png=PNG Sequence
 
+replaymod.gui.rendersettings.antialiasing=Anti-Aliasing
+replaymod.gui.rendersettings.antialiasing.none=None
+replaymod.gui.rendersettings.antialiasing.x2=2x
+replaymod.gui.rendersettings.antialiasing.x4=4x
+replaymod.gui.rendersettings.antialiasing.x8=8x
+
 #Rendering GUI
 replaymod.gui.rendering.title=Rendering Video
 replaymod.gui.rendering.pause=Pause Rendering


### PR DESCRIPTION
Added an Anti-Aliasing option to the Render Settings (disabled by default, up to 8x).
When enabled, the video is rendered at a higher resolution and scaled down using ffmpeg to provide smoother edges.

How it looks in the render menu:
![2016-12-16_03 12 06](https://cloud.githubusercontent.com/assets/10288753/21249330/8b01ec2a-c33d-11e6-93bb-e75997ecbb40.png)

Here's a frame, rendered at 1080p, without anti-aliasing:
![noaa png-000018](https://cloud.githubusercontent.com/assets/10288753/21249345/9fecb502-c33d-11e6-9971-d6ea4b796672.png)
Here's the same frame with 4x anti-aliasing:
![aa4 png-000018](https://cloud.githubusercontent.com/assets/10288753/21249342/9cf8370e-c33d-11e6-9a00-302800d950a6.png)
