### PR TITLE
Don't create an empty directory with no modcore available

### DIFF
--- a/src/main/java/com/replaymod/extras/modcore/ModCoreInstaller.java
+++ b/src/main/java/com/replaymod/extras/modcore/ModCoreInstaller.java
@@ -122,17 +122,17 @@ public class ModCoreInstaller {
 
     public static int initialize(File gameDir, String minecraftVersion) {
         if (isInitalized()) return -1;
+        JsonHolder jsonHolder = fetchJSON(VERSION_URL);
+        if (!jsonHolder.has(minecraftVersion)) {
+            System.out.println("No ModCore target for " + minecraftVersion + ". This in fine, unless you're specifically looking for ModCore.");
+            return -2;
+        }
         dataDir = new File(gameDir, "modcore");
         if (!dataDir.exists()) {
             if (!dataDir.mkdirs()) {
                 bail("Unable to create necessary files");
                 return 1;
             }
-        }
-        JsonHolder jsonHolder = fetchJSON(VERSION_URL);
-        if (!jsonHolder.has(minecraftVersion)) {
-            System.out.println("No ModCore target for " + minecraftVersion + ". This in fine, unless you're specifically looking for ModCore.");
-            return -2;
         }
         String latestRemote = jsonHolder.optString(minecraftVersion);
         boolean failed = jsonHolder.getKeys().size() == 0 || (jsonHolder.has("success") && !jsonHolder.optBoolean("success"));


### PR DESCRIPTION
Currently, the ModCoreInstaller first creates its folder, and after that checks if there is a version available for the current Minecraft version.
Since ModCore is only available for 1.8.9, in all other versions the installer leaves an empty folder in the profile directory every time you open the game, so there is no feasible way to delete it without it coming back next launch.

This PR simply rearranges the version checking to be _before_ the folder is created, so it won't be created if there isn't an available version.
No functionality should have changed.