### PR TITLE
Updated location of windows binaries for ffmpeg now that zeranoe is discontinued.

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -20,7 +20,7 @@ After installing Forge, simply put the downloaded `ReplayMod.jar` file in the `/
 To render your creations with **Replay Mod** you will need to have FFmpeg installed.
 
 ### Windows [windows]
-Download the **latest** FFmpeg build from <http://ffmpeg.zeranoe.com/builds/>.
+Download the **latest** FFmpeg build from <https://www.gyan.dev/ffmpeg/builds/> (the essentials version is sufficient).
 
 In your `.minecraft` folder, create a `ffmpeg` folder. Extract the downloaded .zip file into this folder. The FFmpeg executable should end up at `.minecraft\ffmpeg\bin\ffmpeg.exe`.
 


### PR DESCRIPTION
Added link to https://www.gyan.dev/ffmpeg/builds/ for binaries.