### PR TITLE
Prevent stopping camera path from bloating logs

### DIFF
--- a/src/main/java/com/replaymod/simplepathing/gui/GuiPathing.java
+++ b/src/main/java/com/replaymod/simplepathing/gui/GuiPathing.java
@@ -48,6 +48,7 @@ import de.johni0702.minecraft.gui.utils.Colors;
 import de.johni0702.minecraft.gui.utils.lwjgl.ReadableDimension;
 import de.johni0702.minecraft.gui.utils.lwjgl.ReadablePoint;
 import de.johni0702.minecraft.gui.utils.lwjgl.WritablePoint;
+import java.util.concurrent.CancellationException;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.util.crash.CrashReport;
 import org.apache.logging.log4j.LogManager;
@@ -258,7 +259,11 @@ public class GuiPathing {
             @Override
             public void run() {
                 if (player.isActive()) {
-                    player.getFuture().cancel(false);
+                    try {
+                        player.getFuture().cancel(false);
+                    } catch (CancellationException error) {
+                        // No need to call core.printInfoChat("replaymod.chat.pathinterrupted") since that is done later in callbacks   
+                    }
                 } else {
                     boolean ignoreTimeKeyframes = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT);
 


### PR DESCRIPTION
Every time the camera path is stopped, something like this gets printed in the logs:
```
[20:12:22] [main/INFO]: [CHAT] [Replay Mod] Camera Path started
[20:12:46] [main/INFO]: [STDERR]: java.util.concurrent.CancellationException: Task was cancelled.
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture.cancellationExceptionWithCause(AbstractFuture.java:1114)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:500)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:461)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:78)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:142)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.Futures.getDone(Futures.java:1174)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.Futures$4.run(Futures.java:1124)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:902)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:813)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture.cancel(AbstractFuture.java:553)
[20:12:46] [main/INFO]: [STDERR]: 	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.cancel(AbstractFuture.java:106)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.simplepathing.gui.GuiPathing$10.run(GuiPathing.java:261)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.element.AbstractGuiClickable.onClick(AbstractGuiClickable.java:71)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.element.AbstractGuiButton.onClick(AbstractGuiButton.java:145)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.element.AbstractGuiClickable.mouseClick(AbstractGuiClickable.java:53)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[20:12:46] [main/INFO]: [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.element.AbstractComposedGuiElement$3.invoke(AbstractComposedGuiElement.java:150)
[20:12:46] [main/INFO]: [STDERR]: 	at com.sun.proxy.$Proxy27.mouseClick(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[20:12:46] [main/INFO]: [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.element.AbstractComposedGuiElement$3.invoke(AbstractComposedGuiElement.java:147)
[20:12:46] [main/INFO]: [STDERR]: 	at com.sun.proxy.$Proxy27.mouseClick(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[20:12:46] [main/INFO]: [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.element.AbstractComposedGuiElement$2.invoke(AbstractComposedGuiElement.java:80)
[20:12:46] [main/INFO]: [STDERR]: 	at com.sun.proxy.$Proxy27.mouseClick(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at com.replaymod.lib.de.johni0702.minecraft.gui.container.AbstractGuiOverlay$UserInputGuiScreen.method_25402(AbstractGuiOverlay.java:339)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312.method_1611(class_312.java:92)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312$$Lambda$3269/803304190.run(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_437.method_25412(class_437.java:435)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312.method_1601(class_312.java:92)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312.method_22686(class_312.java:162)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312$$Lambda$3268/1866296242.run(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_1255.execute(class_1255.java:104)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312.method_22684(class_312.java:162)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_312$$Lambda$2516/1892481313.invoke(Unknown Source)
[20:12:46] [main/INFO]: [STDERR]: 	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:36)
[20:12:46] [main/INFO]: [STDERR]: 	at org.lwjgl.system.JNI.invokeV(Native Method)
[20:12:46] [main/INFO]: [STDERR]: 	at org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3101)
[20:12:46] [main/INFO]: [STDERR]: 	at com.mojang.blaze3d.systems.RenderSystem.flipFrame(RenderSystem.java:102)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_1041.method_15998(class_1041.java:384)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_310.method_1523(class_310.java:1068)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.class_310.method_1514(class_310.java:681)
[20:12:46] [main/INFO]: [STDERR]: 	at net.minecraft.client.main.Main.main(Main.java:215)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[20:12:46] [main/INFO]: [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[20:12:46] [main/INFO]: [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[20:12:46] [main/INFO]: [STDERR]: 	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:224)
[20:12:46] [main/INFO]: [STDERR]: 	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:141)
[20:12:46] [main/INFO]: [STDERR]: 	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:27)
```
For an expected code flow, its bad to have this bloat the log files. Something like this is way nicer:
```
[20:12:46] [main/INFO]: [CHAT] [Replay Mod] Camera Path stopped
```
Ignoring this `CancellationException` stops the bloating.

Note: I do not have an IDE to test this, so a quick intellisense verification is necessary.