### PR TITLE
Update common.gradle (spongepowered to use https)

### DIFF
--- a/versions/common.gradle
+++ b/versions/common.gradle
@@ -189,7 +189,7 @@ repositories {
     mavenLocal()
     maven {
         name = "SpongePowered Repo"
-        url = "http://repo.spongepowered.org/maven/"
+        url = "https://repo.spongepowered.org/maven/"
     }
     maven {
         name = "fabric"


### PR DESCRIPTION
Stable and develop are returning 520 from CloudFlare, looks like they've switched the maven repository to use https.