### PR TITLE
Sync world border animation & movement to Replay speed

### DIFF
--- a/src/main/java/com/replaymod/replay/mixin/MixinRenderWorldBorder.java
+++ b/src/main/java/com/replaymod/replay/mixin/MixinRenderWorldBorder.java
@@ -1,0 +1,24 @@
+package com.replaymod.replay.mixin;
+
+import com.replaymod.core.versions.MCVer;
+import com.replaymod.replay.ReplayHandler;
+import com.replaymod.replay.ReplayModReplay;
+import net.minecraft.client.render.WorldRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = WorldRenderer.class, targets = "net.minecraft.world.border.WorldBorder.MovingArea")
+public class MixinRenderWorldBorder {
+
+    // Normally Minecraft's world border movement/animation is based off real time;
+    // this redirect ensures that it is synced with the time in the Replay instead.
+    @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;getMeasuringTimeMs()J"))
+    private long getWorldBorderTime() {
+        ReplayHandler replayHandler = ReplayModReplay.instance.getReplayHandler();
+        if (replayHandler != null) {
+            return replayHandler.getReplaySender().currentTimeStamp();
+        }
+        return MCVer.milliTime();
+    }
+}

--- a/src/main/resources/mixins.replay.replaymod.json
+++ b/src/main/resources/mixins.replay.replaymod.json
@@ -41,7 +41,8 @@
     "MixinRenderItem",
     "MixinRenderLivingBase",
     "MixinTileEntityEndPortalRenderer",
-    "MixinWorldClient"
+    "MixinWorldClient",
+    "MixinRenderWorldBorder"
   ],
   "compatibilityLevel": "JAVA_8",
   "minVersion": "0.6.11",


### PR DESCRIPTION
Fixes an issue where the world border would move at normal speed when speeding up or slowing down the replay, and also at an incorrect speed when rendering the replay, causing it to get out of sync with the rest of the world.

I have tested this with Fabric for Minecraft versions 1.17.1, 1.17, 1.16.4, 1.15.2 and 1.14.4. I have not been able to test this for the older Forge versions yet.