### PR TITLE
#338 Fix Render GUI rendering on Retina Screens

### DIFF
--- a/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
+++ b/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
@@ -119,6 +119,7 @@ public class VideoRenderer implements RenderInfo {
     private volatile Throwable failureCause;
 
     private Framebuffer guiFramebuffer;
+    private int displayWidth, displayHeight;
     private int framebufferWidth, framebufferHeight;
 
     public VideoRenderer(RenderSettings settings, ReplayHandler replayHandler, Timeline timeline) throws IOException {

--- a/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
+++ b/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
@@ -631,8 +631,8 @@ public class VideoRenderer implements RenderInfo {
     }
 
     private boolean displaySizeChanged() {
-        int realWidth = mc.getWindow().getWidth();
-        int realHeight = mc.getWindow().getHeight();
+        int realWidth = mc.getWindow().getFramebufferWidth();
+        int realHeight = mc.getWindow().getFramebufferHeight();
         if (realWidth == 0 || realHeight == 0) {
             // These can be zero on Windows if minimized.
             // Creating zero-sized framebuffers however will throw an error, so we never want to switch to zero values.
@@ -642,8 +642,8 @@ public class VideoRenderer implements RenderInfo {
     }
 
     private void updateDisplaySize() {
-        displayWidth = mc.getWindow().getWidth();
-        displayHeight = mc.getWindow().getHeight();
+        displayWidth = mc.getWindow().getFramebufferWidth();
+        displayHeight = mc.getWindow().getFramebufferHeight();
     }
 
     public int getFramesDone() {


### PR DESCRIPTION
Fixes #338 

window.getFramebufferWidth/Height() should be used instead of window.getWidth/Height().

Tested with a retina screen macbook on 1.18.1.

<img width="966" alt="Screen Shot 2021-12-25 at 8 02 59 PM" src="https://user-images.githubusercontent.com/13282284/147396375-031424e9-88fd-4e46-a5c3-a4e452c000bf.png">

