### PR TITLE
[WIP] optimizations to ffmpeg IPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -334,6 +334,8 @@ dependencies {
         shadow 'org.apache.maven:maven-artifact:3.6.1'
     }
 
+    shadow 'com.zaxxer:nuprocess:2.0.2'
+
     shadow 'org.aspectj:aspectjrt:1.8.2'
 
     shadow 'com.github.ReplayMod.JavaBlend:2.79.0:a0696f8'


### PR DESCRIPTION
On my Windows system, the bottleneck of replay rendering is writing the data to FFmpeg. A potential explanation could be the low buffer size for piping data on Windows (4kb) or something more intricate.

The current (rough) implementation here tries using a different package called NuProcess instead of the JDK implementation of subprocesses. The critical difference in NuProcess's implementation is that they try to handle the asynchrony. For example, calling their method to write to stdin of the subprocess returns instantly rather than blocking like in the JDK Process library.

The preferred implementation on NuProcess's end is to use a callback to signal when the subprocess is ready for input, but this would require a lot of rearchitecting of the threading for rendering and, ultimately, might not even give any performance issues since NuProcess also uses the same 4kb buffer size on Windows.

Another alternative could be a memory-mapped file, this would almost certainly be the fastest, but I'm not sure how FFmpeg would read from this or how ReplayMod would know the status of FFmpeg.

I am opening this PR as a WIP to discuss how to proceed.