### PR TITLE
Modified FREX Flawless Frames notice to be more helpful

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -619,7 +619,7 @@ The _Baritone_ mod can cause a crash when you're trying to load a replay. If you
 Minecraft may crash if you try to use _RandomPatches_ together with ReplayMod. Try removing RandomPatches if Minecraft crashes on startup.
 
 ### Sodium [sodium]
-ReplayMod can record when _Sodium_ is installed but will crash during render. Disable Sodium before rendering, it can be re-enabled after that.
+ReplayMod can record when _Sodium_ is installed, but currently lacks the FREX Flawless Frames API to render. A modified build of _Sodium_, that supports this API, is available from the ReplayMod downloads, by clicking the `Click to show compatible Sodium versions` button.
 
 ### Resource Loader [resourceloader]
 The _Resource Loader_ mod is not compatible with ReplayMod.

--- a/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
+++ b/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
@@ -642,7 +642,7 @@ public class VideoRenderer implements RenderInfo {
             return new String[] {
                     "Rendering is not supported with your Sodium version.",
                     "It is missing support for the FREX Flawless Frames API.",
-                    "Either update to the latest version or uninstall Sodium before rendering!",
+                    "Either use the Sodium build from replaymod.com or uninstall Sodium before rendering!",
             };
         }
         //#if MC>=11700


### PR DESCRIPTION
The current notice does not provide helpful information to solve the problem. 
No official Sodium version supports Flawless Frames, and deleting Sodium is usually not desirable.

The correct solution would be to use a compatible build of Sodium, but coming to that conclusion is not trivial. The in-game text is misleading, along with the current documentation. The only way to find out about the fix is to use third-party guides, deduce it from the "Click to show compatible Sodium versions" button, or ask for help in our support Discord. 