### PR TITLE
Add keybinds for skipping and rewinding specific time periods in the replay viewer

### DIFF
--- a/src/main/java/com/replaymod/core/utils/Utils.java
+++ b/src/main/java/com/replaymod/core/utils/Utils.java
@@ -236,6 +236,22 @@ public class Utils {
         //#endif
     }
 
+    public static boolean isAltDown() {
+        //#if MC>=11400
+        return Screen.hasAltDown();
+        //#else
+        //$$ return Keyboard.isKeyDown(Keyboard.KEY_LMENU) || Keyboard.isKeyDown(Keyboard.KEY_RMENU);
+        //#endif
+    }
+
+    public static boolean isShiftDown() {
+        //#if MC>=11400
+        return Screen.hasShiftDown();
+        //#else
+        //$$ return Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+        //#endif
+    }
+
     public static <T> void addCallback(ListenableFuture<T> future, Consumer<T> onSuccess, Consumer<Throwable> onFailure) {
         Futures.addCallback(future, new FutureCallback<T>() {
             @Override

--- a/src/main/java/com/replaymod/replay/ReplayHandler.java
+++ b/src/main/java/com/replaymod/replay/ReplayHandler.java
@@ -130,6 +130,7 @@ import javax.annotation.Nullable;
 import static com.replaymod.core.utils.Utils.DEFAULT_MS_PER_TICK;
 import static com.replaymod.core.versions.MCVer.*;
 import static com.replaymod.replay.ReplayModReplay.LOGGER;
+import static de.johni0702.minecraft.gui.utils.Utils.clamp;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 
@@ -607,6 +608,31 @@ public class ReplayHandler {
         if (cam != null && targetCameraPosition != null) {
             cam.setCameraPosRot(targetCameraPosition);
         }
+    }
+
+    public void relativeJumpButton(boolean forward) {
+        int skipTime = 1000;
+
+        if (Utils.isShiftDown()) {
+            skipTime = 50;
+        }
+
+        if (Utils.isCtrlDown()) {
+            skipTime *= 10;
+        }
+
+        if (Utils.isAltDown()) {
+            skipTime *= 30;
+        }
+
+        if (!forward) {
+            skipTime = -skipTime;
+        }
+
+        int targetTime = getReplaySender().currentTimeStamp() + skipTime;
+        targetTime = clamp(targetTime, 0, replayDuration);
+
+        doJump(targetTime, true);
     }
 
     public void doJump(int targetTime, boolean retainCameraPosition) {

--- a/src/main/java/com/replaymod/replay/ReplayModReplay.java
+++ b/src/main/java/com/replaymod/replay/ReplayModReplay.java
@@ -8,6 +8,7 @@ import com.replaymod.core.KeyBindingRegistry;
 import com.replaymod.core.Module;
 import com.replaymod.core.ReplayMod;
 import com.replaymod.core.utils.ModCompat;
+import com.replaymod.core.utils.Utils;
 import com.replaymod.core.versions.MCVer;
 import com.replaymod.core.versions.MCVer.Keyboard;
 import com.replaymod.replay.camera.CameraController;
@@ -131,6 +132,24 @@ public class ReplayModReplay implements Module {
 
         core.getKeyBindingRegistry().registerKeyBinding("replaymod.input.resettilt", Keyboard.KEY_K, () -> {
             Optional.ofNullable(replayHandler).map(ReplayHandler::getCameraEntity).ifPresent(c -> c.roll = 0);
+        }, true);
+
+        registry.registerKeyBinding("replaymod.input.skip", Keyboard.KEY_RIGHT, new Runnable() {
+            @Override
+            public void run() {
+                if (replayHandler != null) {
+                    replayHandler.relativeJumpButton(true);
+                }
+            }
+        }, true);
+
+        registry.registerKeyBinding("replaymod.input.rewind", Keyboard.KEY_LEFT, new Runnable() {
+            @Override
+            public void run() {
+                if (replayHandler != null) {
+                    replayHandler.relativeJumpButton(false);
+                }
+            }
         }, true);
     }
 


### PR DESCRIPTION
This PR adds the right and left arrow buttons as shortcuts to the replay viewer, which skip (or rewind) one second.

By using modifier keys, a shorter or longer duration can be used:
SHIFT: 1 tick
CTRL: 10 seconds
ALT: 30 seconds

Multiple modifiers can be combined to multiply their changes. For example:
CTRL + SHIFT -> 10 ticks (0.5 seconds)
CTRL + ALT -> 300 seconds (5 minutes)


Do I just make a PR to the translations repo for the two translations I added? If so, should I translate them to my native language (German) immediately?