### PR TITLE
fix split replays with cuts having wrong start timestamps

### DIFF
--- a/src/main/java/com/replaymod/editor/gui/MarkerProcessor.java
+++ b/src/main/java/com/replaymod/editor/gui/MarkerProcessor.java
@@ -151,13 +151,16 @@ public class MarkerProcessor {
             PacketData nextPacket = replayInputStream.readPacket();
             Marker nextMarker = markerIterator.next();
 
+            long startDate = -1;
             while (nextPacket != null && outputFileSuffixes.hasNext()) {
                 Path outputPath = path.resolveSibling(replayName + outputFileSuffixes.next() + ".mcpr");
                 try (ReplayFile outputReplayFile = mod.files.open(null, outputPath)) {
                     long duration = 0;
                     Set<Marker> outputMarkers = new HashSet<>();
                     ReplayMetaData metaData = inputReplayFile.getMetaData();
-                    metaData.setDate(metaData.getDate() + timeOffset);
+                    if (startDate == -1) {
+                        startDate = metaData.getDate();
+                    }
 
                     try (ReplayOutputStream replayOutputStream = outputReplayFile.writePacketData()) {
                         if (cutFilter != null) {
@@ -184,6 +187,7 @@ public class MarkerProcessor {
                                     startCutOffset = nextMarker.getTime();
                                     cutFilter = new SquashFilter(dimensionTracker);
                                 } else if (MARKER_NAME_END_CUT.equals(nextMarker.getName())) {
+                                    metaData.setDate(startDate + nextMarker.getTime());
                                     timeOffset += nextMarker.getTime() - startCutOffset;
                                     if (cutFilter != null) {
                                         List<PacketData> packets = new ArrayList<>();


### PR DESCRIPTION
uncut
"duration": 12975,
"date": 1755021910454, // 8/12/2025, 9:05:10 PM

first cut
"duration1": 3690,
"date1": 1755021910454, // 8/12/2025, 9:05:10 PM

second cut
"duration2": 5956,
"date2": 1755021914148 // 8/12/2025, 9:05:14 PM
date ends up being first segment start + first segment length (1755021910454 + 3690)
since we have the full replay to test, can check the real full time: 12975
so the real start date should be first segment start + first segment length + second (cut) segment length, 1755021910454 + 3690 + (12975 - 3690 - 5956)

after fixes:

uncut
"duration": 23803,
"date": 1755029588637 // 8/12/2025, 11:13:08 PM

first cut
"duration1": 7876,
"date1": 1755029588637 // 8/12/2025, 11:13:08 PM

second cut
"duration2": 3964,
"date2": 1755029600242 // 8/12/2025, 11:13:20 PM (includes cut time: 1755029600242 - 1755029588637 = 11605, 11605 - 7876 = 3729 <- trimmed time)

third cut
"duration3": 4574,
"date3": 1755029607866 // 8/12/2025, 11:13:27 PM (1755029607866 - 1755029600242 = 7624, 7624 - 3964 = 3660 <- trimmed time)