### PR TITLE
Use VP9 for WEBM preset

### DIFF
--- a/src/main/java/com/replaymod/render/RenderSettings.java
+++ b/src/main/java/com/replaymod/render/RenderSettings.java
@@ -65,7 +65,7 @@ public class RenderSettings {
 
         MP4_POTATO("-an -c:v libx264 -preset ultrafast -crf 51 -pix_fmt yuv420p \"%FILENAME%\"", "mp4"),
 
-        WEBM_CUSTOM("-an -c:v libvpx -b:v %BITRATE% -pix_fmt yuv420p \"%FILENAME%\"", "webm"),
+        WEBM_CUSTOM("-an -c:v libvpx-vp9 -b:v %BITRATE% -pix_fmt yuv420p \"%FILENAME%\"", "webm"),
 
         MKV_LOSSLESS("-an -c:v libx264 -preset ultrafast -qp 0 \"%FILENAME%\"", "mkv"),
 


### PR DESCRIPTION
VP9 has been out long enough that it has become the de facto replacement for VP8.